### PR TITLE
Expanded dynamic loading from DB to all product pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,19 +82,36 @@ app.get("/logout", function(req, res) {
 });
 
 app.get("/potions", function(req, res) {
-   res.render("potions");
+   // res.render("potions");
+   let sql = "SELECT * FROM Products WHERE type= 'Potion'";
+   pool.query(sql, function(err, rows, fields) {
+      if (err) throw err;
+      //console.log(rows);
+      res.render("potions", { "rows": rows });
+   });
 });
 
 app.get("/weapons", function(req, res) {
-   res.render("weapons");
+   let sql = "SELECT * FROM Products WHERE type= 'Weapon'";
+   pool.query(sql, function(err, rows, fields) {
+      if (err) throw err;
+      //console.log(rows);
+      res.render("weapons", { "rows": rows });
+   });
 });
 
 app.get("/armor", function(req, res) {
-   res.render("armor");
+   // res.render("armor");
+   let sql = "SELECT * FROM Products WHERE type= 'Armor'";
+   pool.query(sql, function(err, rows, fields) {
+      if (err) throw err;
+      //console.log(rows);
+      res.render("armor", { "rows": rows });
+   });
 });
 
 app.get("/wands", function(req, res) {
-   let sql = "SELECT * FROM Products WHERE type= 'Weapon'";
+   let sql = "SELECT * FROM Products WHERE type= 'Wand'";
    pool.query(sql, function(err, rows, fields) {
       if (err) throw err;
       //console.log(rows);
@@ -103,7 +120,13 @@ app.get("/wands", function(req, res) {
 });
 
 app.get("/crystals", function(req, res) {
-   res.render("crystals");
+   // res.render("crystals");
+   let sql = "SELECT * FROM Products WHERE type= 'Crystal'";
+   pool.query(sql, function(err, rows, fields) {
+      if (err) throw err;
+      //console.log(rows);
+      res.render("crystals", { "rows": rows });
+   });
 });
 
 app.get("/signup", function(req, res) {

--- a/views/armor.ejs
+++ b/views/armor.ejs
@@ -2,7 +2,28 @@
    <%- include('partials/navbar.ejs') %>
     
    <!-- Front End Design for Armor Page -->
-   <p> DEV NOTE: Armor needs to be implemented </p>
+   <!--<p> DEV NOTE: Armor needs to be implemented </p>-->
+   
+   <h1>Alchemist's Shop</h1>
+      <hr />
+      <!-- Display Case Container -->
+      <div id="armor-display" class="container">
+         <!--displaying products-->
+         <% rows.forEach(function(row){ %>
+         <div class="box blue-box product-container">
+            <form action="/api/addToCart" method="GET">
+               <img src='<%= row.imageUrl %>' width='210' alt='<%= row.imageUrl %>'/>
+               <br />
+               <h5><%= row.name %></h5>
+               <p><%= row.price %> Denars</p>
+               <input type="hidden" name="product_id" value='<%= row.productId %>'>
+               <input type="hidden" name="product_name" value='<%= row.name %>'>      
+               <input type="hidden" name="product_price" value='<%= row.price %>'>
+               <input class="add-to-cart" type="submit" value="Add To Cart">
+            </form>
+         </div>
+         <% }); %>
+      </div> <!-- ends display case container -->
     
    <%- include('partials/footer.ejs') %>
    </body>

--- a/views/armor.ejs
+++ b/views/armor.ejs
@@ -4,7 +4,7 @@
    <!-- Front End Design for Armor Page -->
    <!--<p> DEV NOTE: Armor needs to be implemented </p>-->
    
-   <h1>Alchemist's Shop</h1>
+   <h1>Armorsmith's Shop</h1>
       <hr />
       <!-- Display Case Container -->
       <div id="armor-display" class="container">

--- a/views/crystals.ejs
+++ b/views/crystals.ejs
@@ -2,7 +2,28 @@
    <%- include('partials/navbar.ejs') %>
    
    <!-- Front End Design for Crystals Page -->
-   <p> DEV NOTE: Crystals needs to be implemented </p>
+   <!--<p> DEV NOTE: Crystals needs to be implemented </p>-->
+   
+   <h1>Crystal Shop</h1>
+      <hr />
+      <!-- Display Case Container -->
+      <div id="crystal-display" class="container">
+         <!--displaying products-->
+         <% rows.forEach(function(row){ %>
+         <div class="box blue-box product-container">
+            <form action="/api/addToCart" method="GET">
+               <img src='<%= row.imageUrl %>' width='210' alt='<%= row.imageUrl %>'/>
+               <br />
+               <h5><%= row.name %></h5>
+               <p><%= row.price %> Denars</p>
+               <input type="hidden" name="product_id" value='<%= row.productId %>'>
+               <input type="hidden" name="product_name" value='<%= row.name %>'>      
+               <input type="hidden" name="product_price" value='<%= row.price %>'>
+               <input class="add-to-cart" type="submit" value="Add To Cart">
+            </form>
+         </div>
+         <% }); %>
+      </div> <!-- ends display case container -->
     
    <%- include('partials/footer.ejs') %>
    </body>

--- a/views/potions.ejs
+++ b/views/potions.ejs
@@ -1,70 +1,92 @@
    <%- include('partials/header.ejs') %>
    <%- include('partials/navbar.ejs') %>
   
-   <br>
-   <br>
-   <br>
-   <br>
+   <!--<br>-->
+   <!--<br>-->
+   <!--<br>-->
+   <!--<br>-->
    <body>
-       
-   <div class = "container">
+      
       <h1>Alchemist's Shop</h1>
-      <hr>
+      <hr />
+      <!-- Display Case Container -->
+      <div id="potions-display" class="container">
+         <!--displaying potion products-->
+         <% rows.forEach(function(row){ %>
+         <div class="box blue-box product-container">
+            <form action="/api/addToCart" method="GET">
+               <img src='<%= row.imageUrl %>' width='210' alt='<%= row.imageUrl %>'/>
+               <br />
+               <h5><%= row.name %></h5>
+               <p><%= row.price %> Denars</p>
+               <input type="hidden" name="product_id" value='<%= row.productId %>'>
+               <input type="hidden" name="product_name" value='<%= row.name %>'>      
+               <input type="hidden" name="product_price" value='<%= row.price %>'>
+               <input class="add-to-cart" type="submit" value="Add To Cart">
+            </form>
+         </div>
+         <% }); %>
+      </div> <!-- ends display case container -->
+   
+   
+   <!--<div class = "container">-->
+   <!--   <h1>Alchemist's Shop</h1>-->
+   <!--   <hr>-->
           
       
-      <div class = "box blue-box">
-          <img class ="potions" src='img/purple-bottle.jpg' width='200'>
-          <h5>Purple potion</h5>
-          <p>600 Denar</p>
-          <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--   <div class = "box blue-box">-->
+   <!--       <img class ="potions" src='img/purple-bottle.jpg' width='200'>-->
+   <!--       <h5>Purple potion</h5>-->
+   <!--       <p>600 Denar</p>-->
+   <!--       <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
       
      
-      <div class = "box blue-box">
+   <!--   <div class = "box blue-box">-->
          <!--Created By ButterflyNature-->
-         <img class ="potions" src='img/glowing-blue-bottle.jpg' width='210'>
-         <h5>Blue Potion</h5>
-         <p>200 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--      <img class ="potions" src='img/glowing-blue-bottle.jpg' width='210'>-->
+   <!--      <h5>Blue Potion</h5>-->
+   <!--      <p>200 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
       
-      <div class = "box blue-box">
+   <!--   <div class = "box blue-box">-->
          <!--Created by Dana Horne-->
-         <img class ="potions" src='img/glowing-green-bottle.jpg' width='210'>
-         <h5>Green Potion</h5>
-         <p>30 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--      <img class ="potions" src='img/glowing-green-bottle.jpg' width='210'>-->
+   <!--      <h5>Green Potion</h5>-->
+   <!--      <p>30 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
       
       <!--<Creator(s) are probably found here: https://samequizy.pl/co-bys-mogl-zrobic-ze-swoimi-pieniedzmi/-->
-      <div class = "box blue-box" style="margin-top: 60px;">
+   <!--   <div class = "box blue-box" style="margin-top: 60px;">-->
          <!--Created by  Cyndi Booth-->
-         <img class ="potions" src='img/silver-bottle.jpg' width='210'>
-         <h5>Silver Potion</h5>
-         <p>500 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--      <img class ="potions" src='img/silver-bottle.jpg' width='210'>-->
+   <!--      <h5>Silver Potion</h5>-->
+   <!--      <p>500 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
       
-      <div class = "box blue-box" style="margin-top: 60px;">
+   <!--   <div class = "box blue-box" style="margin-top: 60px;">-->
          <!--Created by pilotneko-->
-         <img class ="potions" src='img/blue-gold-bottles.jpg' width='210'>
-         <h5>Blue-Gold Potion</h5>
-         <p>900 Denar</p>
-         <a class="add-cart cart1"
-         href="#">Add to Cart</a>
-      </div>
+   <!--      <img class ="potions" src='img/blue-gold-bottles.jpg' width='210'>-->
+   <!--      <h5>Blue-Gold Potion</h5>-->
+   <!--      <p>900 Denar</p>-->
+   <!--      <a class="add-cart cart1"-->
+   <!--      href="#">Add to Cart</a>-->
+   <!--   </div>-->
       
       <!--<Creator(s) are probably found here: https://samequizy.pl/co-bys-mogl-zrobic-ze-swoimi-pieniedzmi/-->
-      <div class = "box blue-box" style="margin-top: 60px;">
-         <img class ="potions" src='img/green-bottle.jpg' width='210'>
-         <h5>Green Potion</h5>
-         <p>100 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--   <div class = "box blue-box" style="margin-top: 60px;">-->
+   <!--      <img class ="potions" src='img/green-bottle.jpg' width='210'>-->
+   <!--      <h5>Green Potion</h5>-->
+   <!--      <p>100 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
       
-   </div>
+   <!--</div>-->
 
-   <%- include('partials/footer.ejs') %>
+      <%- include('partials/footer.ejs') %>
    </body>
 </html>
 

--- a/views/wands.ejs
+++ b/views/wands.ejs
@@ -2,9 +2,9 @@
    <%- include('partials/navbar.ejs') %>
    
    <!-- Front End Design for Wands Page -->
-   <p> DEV NOTE: Wands is being used as a testing page for dynamically creating content </p>
+   <!--<p> DEV NOTE: Wands is being used as a testing page for dynamically creating content </p>-->
 
-   <h1>Wands's Shop</h1>
+   <h1>Wand Shop</h1>
    <hr>
           
    <!-- Display Case Container -->

--- a/views/weapons.ejs
+++ b/views/weapons.ejs
@@ -1,73 +1,95 @@
    <%- include('partials/header.ejs') %>
    <%- include('partials/navbar.ejs') %>
 
-   <br>
-   <br>
-   <br>
-   <br>
+   <!--<br>-->
+   <!--<br>-->
+   <!--<br>-->
+   <!--<br>-->
    <body>
-       
-   <div class = "container">
+      
       <h1>Blacksmith's Shop</h1>
-      <hr>
-          
-      <div class = "box blue-box">
-         <!--Created by FantasyStock-->
-         <img class ="weapons" src='img/golden-rune-sword.jpg' width='200'>
-         <h5>Golden Rune Sword</h5>
-         <p>2000 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+      <hr />
+      <!-- Display Case Container -->
+      <div id="weapons-display" class="container">
+         <!--displaying weapon products-->
+         <% rows.forEach(function(row){ %>
+         <div class="box blue-box product-container">
+            <form action="/api/addToCart" method="GET">
+               <img src='<%= row.imageUrl %>' width='210' alt='<%= row.imageUrl %>'/>
+               <br />
+               <h5><%= row.name %></h5>
+               <p><%= row.price %> Denars</p>
+               <input type="hidden" name="product_id" value='<%= row.productId %>'>
+               <input type="hidden" name="product_name" value='<%= row.name %>'>      
+               <input type="hidden" name="product_price" value='<%= row.price %>'>
+               <input class="add-to-cart" type="submit" value="Add To Cart">
+            </form>
+         </div>
+         <% }); %>
            
-      <div class = "box blue-box">
+      </div> <!-- ends display case container -->
+       
+   <!--<div class = "container">-->
+   <!--   <h1>Blacksmith's Shop</h1>-->
+   <!--   <hr>-->
+          
+   <!--   <div class = "box blue-box">-->
+         <!--Created by FantasyStock-->
+   <!--      <img class ="weapons" src='img/golden-rune-sword.jpg' width='200'>-->
+   <!--      <h5>Golden Rune Sword</h5>-->
+   <!--      <p>2000 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
+           
+   <!--   <div class = "box blue-box">-->
          <!--Created By Make It Sharp-->
-         <img class ="weapons" src='img/falchion-blades.jpg' width='210'>
-         <h5>Falchion Blades</h5>
-         <p>1000 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--      <img class ="weapons" src='img/falchion-blades.jpg' width='210'>-->
+   <!--      <h5>Falchion Blades</h5>-->
+   <!--      <p>1000 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
            
-      <div class = "box blue-box">
+   <!--   <div class = "box blue-box">-->
          <!--Created by FantasyStock-->
-         <img class ="weapons" src='img/robin-of-locksley-sword.jpg' width='210'>
-         <h5> Robin of Locksley Sword</h5>
-         <p>1500 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--      <img class ="weapons" src='img/robin-of-locksley-sword.jpg' width='210'>-->
+   <!--      <h5> Robin of Locksley Sword</h5>-->
+   <!--      <p>1500 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
           
-      <div class = "box blue-box" style="margin-top: -14%; margin-left: -8px;" >
+   <!--   <div class = "box blue-box" style="margin-top: -14%; margin-left: -8px;" >-->
          <!--Created by FantasyStock-->
-         <img class ="weapons" src='img/blue-gem-dagger.jpg' width='210'>
-         <h5>Blue Gem Dagger</h5>
-         <p>300 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--      <img class ="weapons" src='img/blue-gem-dagger.jpg' width='210'>-->
+   <!--      <h5>Blue Gem Dagger</h5>-->
+   <!--      <p>300 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
            
-      <div class = "box blue-box" style="margin-top: -42%;">
+   <!--   <div class = "box blue-box" style="margin-top: -42%;">-->
          <!--Created by FantasyStock-->
-         <img class ="potions" src='img/dragon-scale-dagger.jpg' width='210'>
-         <h5>Dragon Scale Dagger</h5>
-         <p>900 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--      <img class ="potions" src='img/dragon-scale-dagger.jpg' width='210'>-->
+   <!--      <h5>Dragon Scale Dagger</h5>-->
+   <!--      <p>900 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
            
       <!--<Created by Skyrim creators -->
-      <div class = "box blue-box" style="margin-top: -42%;">
-         <img class ="weapons" src='img/auriels-bow.jpg' width='210'>
-         <h5>Auriel's Bow</h5>
-         <p>1400 Denar</p>
-         <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
+   <!--   <div class = "box blue-box" style="margin-top: -42%;">-->
+   <!--      <img class ="weapons" src='img/auriels-bow.jpg' width='210'>-->
+   <!--      <h5>Auriel's Bow</h5>-->
+   <!--      <p>1400 Denar</p>-->
+   <!--      <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
            
       <!-- Created by Rittik-Designs -->
-      <div class = "box blue-box" style="margin-top: -42%;">
-          <img class ="weapons" src='img/twin-blades.jpg' width='210'>
-          <h5>Gold and Cerulean Twin Blades </h5>
-          <p>3000 Denar</p>
-          <a class="add-cart cart1" href="#">Add to Cart</a>
-      </div>
-   </div>
+   <!--   <div class = "box blue-box" style="margin-top: -42%;">-->
+   <!--       <img class ="weapons" src='img/twin-blades.jpg' width='210'>-->
+   <!--       <h5>Gold and Cerulean Twin Blades </h5>-->
+   <!--       <p>3000 Denar</p>-->
+   <!--       <a class="add-cart cart1" href="#">Add to Cart</a>-->
+   <!--   </div>-->
+   <!--</div>-->
          
-   <%- include('partials/footer.ejs') %>
+      <%- include('partials/footer.ejs') %>
    </body>
 </html>   


### PR DESCRIPTION
I expanded Nick's dynamic product loading code from the Wands page to all the product pages, and fixed the Wand page so it will load Wands instead of Weapons (once the wands are added to the db). So once this pull request is merged, products should just need to be added to the DB and they should automatically show up on their respective pages, based on Nick's code and Christal's formatting.